### PR TITLE
Remove constraints from subordinates

### DIFF
--- a/terraform/openstack/applications.tf
+++ b/terraform/openstack/applications.tf
@@ -17,7 +17,6 @@ module "cinder_csi" {
   source      = "git::https://github.com/canonical/cinder-csi-operator//terraform?ref=KU-2415/adding-terraform-modules"
   app_name    = module.cinder_csi_config.config.app_name
   base        = coalesce(module.cinder_csi_config.config.base,        module.openstack_integrator_config.config.base,        var.k8s.config.base)
-  constraints = coalesce(module.cinder_csi_config.config.constraints, module.openstack_integrator_config.config.constraints, var.k8s.config.constraints)
   channel     = coalesce(module.cinder_csi_config.config.channel,     module.openstack_integrator_config.config.channel,     var.k8s.config.channel)
   model       = var.model
   revision    = module.cinder_csi_config.config.revision
@@ -27,7 +26,6 @@ module "openstack_cloud_controller" {
   source      = "git::https://github.com/charmed-kubernetes/openstack-cloud-controller-operator//terraform?ref=KU-2413/adding-terraform-modules"
   app_name    = module.openstack_cloud_controller_config.config.app_name
   base        = coalesce(module.openstack_cloud_controller_config.config.base,        module.openstack_integrator_config.config.base,        var.k8s.config.base)
-  constraints = coalesce(module.openstack_cloud_controller_config.config.constraints, module.openstack_integrator_config.config.constraints, var.k8s.config.constraints)
   channel     = coalesce(module.openstack_cloud_controller_config.config.channel,     module.openstack_integrator_config.config.channel,     var.k8s.config.channel)
   model       = var.model
   revision    = module.openstack_cloud_controller_config.config.revision


### PR DESCRIPTION
* Remove constraints from subordinate applications

fixes client error when deploying on openstack
```sh
╷
│ Error: Client Error
│ 
│   with module.k8s_bundled.module.openstack[0].module.cinder_csi.juju_application.cinder_csi,
│   on .terraform/modules/k8s_bundled.openstack.cinder_csi/terraform/main.tf line 4, in resource "juju_application" "cinder_csi":
│    4: resource "juju_application" "cinder_csi" {
│ 
│ Unable to create application, got error: subordinate application must be deployed without constraints
╵
╷
│ Error: Client Error
│ 
│   with module.k8s_bundled.module.openstack[0].module.openstack_cloud_controller.juju_application.openstack_cloud_controller,
│   on .terraform/modules/k8s_bundled.openstack.openstack_cloud_controller/terraform/main.tf line 4, in resource "juju_application" "openstack_cloud_controller":
│    4: resource "juju_application" "openstack_cloud_controller" {
│ 
│ Unable to create application, got error: subordinate application must be deployed without constraints
```